### PR TITLE
[lint](https://github.com/net-lisias-ksp/ksp-tools-public) to the rescue! :)

### DIFF
--- a/GameData/OPT_Legacy/Parts/Stail/OPT_b_2m_bicoupler.cfg
+++ b/GameData/OPT_Legacy/Parts/Stail/OPT_b_2m_bicoupler.cfg
@@ -46,7 +46,7 @@ PART
 	breakingForce = 600
 	breakingTorque = 600
 	maxTemp = 1500
-	skinMaxTemp 2700
+	skinMaxTemp = 2700
 	fuelCrossFeed = True
 	emissiveConstant = 0.9
 	bulkheadProfiles = Stail, size2


### PR DESCRIPTION
The OPT_b_2m_bicoupler.cfg has a typo on the config file, and this is hindering the skinMaxTemperature of the part.

This pull request fixes it.